### PR TITLE
Point issue tracker to GitHub with the GitHub::Meta Plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,6 +27,6 @@ Pod::Coverage::TrustPod = 0
 [NextRelease]
 format = %v %{yyyy-MM-dd}d
 
-[Repository]
+[GitHub::Meta]
 
 [@Basic]

--- a/lib/HTML/FormFu/Role/JQueryValidation.pm
+++ b/lib/HTML/FormFu/Role/JQueryValidation.pm
@@ -1,4 +1,5 @@
 package HTML::FormFu::Role::JQueryValidation;
+
 use Moose::Role;
 
 use JSON::Any;


### PR DESCRIPTION
This changes the Plugin from the [Repository Plugin](https://metacpan.org/pod/Dist::Zilla::Plugin::Repository) to the [GitHub::Meta Plugin](https://metacpan.org/pod/Dist::Zilla::Plugin::GitHub::Meta) which also adjusts the issue tracker to be GitHub Issues.

While here, I noticed that the PkgVersion Plugin complained about wanting a newline after the package declaration and so I added one.

Got here via the [Pull Request Club](https://pullrequest.club), but there weren't any issues to fix, so I found something that seemed helpful, although rt.cpan is no longer going away as I thought when I was thinking about what change to make.